### PR TITLE
Added namespace to rollout status command

### DIFF
--- a/cf-deploy-kubernetes.sh
+++ b/cf-deploy-kubernetes.sh
@@ -51,7 +51,7 @@ echo "---> Submitting a deployment to Kubernetes by kubectl $KUBECTL_ACTION "
 kubectl $KUBECTL_ACTION -f "$DEPLOYMENT_FILE" || fatal "Deployment submitting Failed"
 
 if [ -n "$DEPLOYMENT_NAME" ]; then
-    echo "---> Waiting for a successful deployment/${DEPLOYMENT_NAME} status..."
-    timeout -s SIGTERM -t $KUBERNETES_DEPLOYMENT_TIMEOUT kubectl rollout status deployment/"${DEPLOYMENT_NAME}" || fatal "Deployment Failed"
+    echo "---> Waiting for a successful deployment/${DEPLOYMENT_NAME} status to namespace ${DEFAULT_NAMESPACE}..."
+    timeout -s SIGTERM -t $KUBERNETES_DEPLOYMENT_TIMEOUT kubectl rollout --namespace ${DEFAULT_NAMESPACE} status deployment/"${DEPLOYMENT_NAME}" || fatal "Deployment Failed"
 fi
 


### PR DESCRIPTION
It seems changes to the kubectl binary caused builds to fail due to the rollout status command not considering the namespace in the deployer.

Adding the namespace explicitly works and I verified it by forking this and pushing to my own docker registry.

Might be related to this:
https://github.com/kubernetes/kubernetes/issues/42364