### PR TITLE
Update default kubectl to version 1.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.6 AS builder
 
 RUN apk update && apk add curl
 
-RUN curl -o kubectl1.9 -L https://storage.googleapis.com/kubernetes-release/release/v1.9.0/bin/linux/amd64/kubectl
+RUN curl -o kubectl1.10 -L https://storage.googleapis.com/kubernetes-release/release/v1.10.0/bin/linux/amd64/kubectl
 RUN curl -o kubectl1.6 -L https://storage.googleapis.com/kubernetes-release/release/v1.6.0/bin/linux/amd64/kubectl
 
 
@@ -11,7 +11,7 @@ FROM alpine:3.6
 RUN apk add --update bash
 
 #copy both versions of kubectl to switch between them later.
-COPY --from=builder kubectl1.9 /usr/local/bin/kubectl
+COPY --from=builder kubectl1.10 /usr/local/bin/kubectl
 COPY --from=builder kubectl1.6 /usr/local/bin/
 
 RUN chmod +x /usr/local/bin/kubectl /usr/local/bin/kubectl1.6


### PR DESCRIPTION
Version of default kubectl was update from 1.9 to 1.10

https://hub.docker.com/r/codefresh/cf-deploy-kubernetes/tags/