### PR TITLE
adding in the new binaries for kubectl v1.14.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM alpine:3.6 AS builder
 
 RUN apk update && apk add curl
 
+RUN curl -o kubectl1.14 -L https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubectl
 RUN curl -o kubectl1.10 -L https://storage.googleapis.com/kubernetes-release/release/v1.10.0/bin/linux/amd64/kubectl
 RUN curl -o kubectl1.6 -L https://storage.googleapis.com/kubernetes-release/release/v1.6.0/bin/linux/amd64/kubectl
 
@@ -11,10 +12,11 @@ FROM alpine:3.6
 RUN apk add --update bash
 
 #copy both versions of kubectl to switch between them later.
-COPY --from=builder kubectl1.10 /usr/local/bin/kubectl
+COPY --from=builder kubectl1.14 /usr/local/bin/kubectl
+COPY --from=builder kubectl1.10 /usr/local/bin/
 COPY --from=builder kubectl1.6 /usr/local/bin/
 
-RUN chmod +x /usr/local/bin/kubectl /usr/local/bin/kubectl1.6
+RUN chmod +x /usr/local/bin/kubectl /usr/local/bin/kubectl1.10 /usr/local/bin/kubectl1.6
 
 WORKDIR /
 

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -2,6 +2,7 @@ FROM multiarch/alpine:aarch64-v3.6 AS builder
 
 RUN apk update && apk add curl
 
+RUN curl -o kubectl1.14 -L https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/arm64/kubectl
 RUN curl -o kubectl1.9 -L https://storage.googleapis.com/kubernetes-release/release/v1.9.0/bin/linux/arm64/kubectl
 RUN curl -o kubectl1.6 -L https://storage.googleapis.com/kubernetes-release/release/v1.6.0/bin/linux/arm64/kubectl
 
@@ -11,10 +12,11 @@ FROM multiarch/alpine:aarch64-v3.6
 RUN apk add --update bash
 
 #copy both versions of kubectl to switch between them later.
-COPY --from=builder kubectl1.9 /usr/local/bin/kubectl
+COPY --from=builder kubectl1.14 /usr/local/bin/kubectl
+COPY --from=builder kubectl1.9 /usr/local/bin/
 COPY --from=builder kubectl1.6 /usr/local/bin/
 
-RUN chmod +x /usr/local/bin/kubectl /usr/local/bin/kubectl1.6
+RUN chmod +x /usr/local/bin/kubectl /usr/local/bin/kubectl1.9 /usr/local/bin/kubectl1.6
 
 WORKDIR /
 


### PR DESCRIPTION
@francisco-codefresh This is to push a new version of our container with the default kubectl v1.14.0 and I've update the pipelines in Codefresh to push that new version when we merge this to master and commented out the original tags as to not push the latest or arm64 tags.

Please review this change and the changes to the associated pipelines.