### PR TITLE
Update kubectl version logic

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,25 @@
-FROM alpine:3.6 AS builder
+FROM alpine:3.9 AS builder
 
 RUN apk update && apk add curl
 
-RUN curl -o kubectl1.14 -L https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubectl
 RUN curl -o kubectl1.15 -L https://storage.googleapis.com/kubernetes-release/release/v1.15.0/bin/linux/amd64/kubectl
+RUN curl -o kubectl1.14 -L https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubectl
+RUN curl -o kubectl1.12 -L https://storage.googleapis.com/kubernetes-release/release/v1.10.0/bin/linux/amd64/kubectl
 RUN curl -o kubectl1.10 -L https://storage.googleapis.com/kubernetes-release/release/v1.10.0/bin/linux/amd64/kubectl
 RUN curl -o kubectl1.6 -L https://storage.googleapis.com/kubernetes-release/release/v1.6.0/bin/linux/amd64/kubectl
 
-
-FROM alpine:3.6
+FROM alpine:3.9
 
 RUN apk add --update bash
 
 #copy all versions of kubectl to switch between them later.
 COPY --from=builder kubectl1.15 /usr/local/bin/
-COPY --from=builder kubectl1.14 /usr/local/bin/
-COPY --from=builder kubectl1.10 /usr/local/bin/kubectl
+COPY --from=builder kubectl1.14 /usr/local/bin/kubectl
+COPY --from=builder kubectl1.12 /usr/local/bin/
+COPY --from=builder kubectl1.10 /usr/local/bin/
 COPY --from=builder kubectl1.6 /usr/local/bin/
 
-RUN chmod +x /usr/local/bin/kubectl /usr/local/bin/kubectl1.6 /usr/local/bin/kubectl1.14 /usr/local/bin/kubectl1.15
+RUN chmod +x /usr/local/bin/kubectl /usr/local/bin/kubectl1.6 /usr/local/bin/kubectl1.10 /usr/local/bin/kubectl1.12 /usr/local/bin/kubectl1.14 /usr/local/bin/kubectl1.15
 
 WORKDIR /
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,12 +14,15 @@ RUN apk add --update bash
 
 #copy all versions of kubectl to switch between them later.
 COPY --from=builder kubectl1.15 /usr/local/bin/
-COPY --from=builder kubectl1.14 /usr/local/bin/kubectl
+COPY --from=builder kubectl1.14 /usr/local/bin/
 COPY --from=builder kubectl1.12 /usr/local/bin/
 COPY --from=builder kubectl1.10 /usr/local/bin/
 COPY --from=builder kubectl1.6 /usr/local/bin/
 
-RUN chmod +x /usr/local/bin/kubectl /usr/local/bin/kubectl1.6 /usr/local/bin/kubectl1.10 /usr/local/bin/kubectl1.12 /usr/local/bin/kubectl1.15
+# Set Default
+COPY --from=builder kubectl1.14 /usr/local/bin/kubectl
+
+RUN chmod +x /usr/local/bin/kubectl /usr/local/bin/kubectl1.6 /usr/local/bin/kubectl1.10 /usr/local/bin/kubectl1.12 /usr/local/bin/kubectl1.14 /usr/local/bin/kubectl1.15
 
 WORKDIR /
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ COPY --from=builder kubectl1.12 /usr/local/bin/
 COPY --from=builder kubectl1.10 /usr/local/bin/
 COPY --from=builder kubectl1.6 /usr/local/bin/
 
-RUN chmod +x /usr/local/bin/kubectl /usr/local/bin/kubectl1.6 /usr/local/bin/kubectl1.10 /usr/local/bin/kubectl1.12 /usr/local/bin/kubectl1.14 /usr/local/bin/kubectl1.15
+RUN chmod +x /usr/local/bin/kubectl /usr/local/bin/kubectl1.6 /usr/local/bin/kubectl1.10 /usr/local/bin/kubectl1.12 /usr/local/bin/kubectl1.15
 
 WORKDIR /
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN apk update && apk add curl
 
 RUN curl -o kubectl1.15 -L https://storage.googleapis.com/kubernetes-release/release/v1.15.0/bin/linux/amd64/kubectl
 RUN curl -o kubectl1.14 -L https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubectl
-RUN curl -o kubectl1.12 -L https://storage.googleapis.com/kubernetes-release/release/v1.10.0/bin/linux/amd64/kubectl
+RUN curl -o kubectl1.12 -L https://storage.googleapis.com/kubernetes-release/release/v1.12.0/bin/linux/amd64/kubectl
 RUN curl -o kubectl1.10 -L https://storage.googleapis.com/kubernetes-release/release/v1.10.0/bin/linux/amd64/kubectl
 RUN curl -o kubectl1.6 -L https://storage.googleapis.com/kubernetes-release/release/v1.6.0/bin/linux/amd64/kubectl
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ The following env variables control the deployment configuration:
 3. KUBERNETES_NAMESPACE - The namespace to deploy
 4. KUBECTL_ACTION - means an action for `kubectl <action>`. Valid values are apply|create|replace. Default is "apply"
 
+Optional:
+`SERVER_VERSION` - Used mainly for testing. Manually set the Minor Kubernetes version.
+
 # Usage in codefresh.io
 
 ### deployment.yml

--- a/cf-deploy-kubernetes.sh
+++ b/cf-deploy-kubernetes.sh
@@ -87,11 +87,9 @@ else
     exit 1
 fi
 
-# Assign kubectl version unless default
-if [[ "${KUBE_CTL}" != "14" ]]; then
-    echo "Setting kubectl to version 1.${KUBE_CTL}"
-    cp -f "/usr/local/bin/kubectl1.${KUBE_CTL}" /usr/local/bin/kubectl
-fi
+# Assign kubectl version 
+echo "Setting kubectl to version 1.${KUBE_CTL}"
+cp -f "/usr/local/bin/kubectl1.${KUBE_CTL}" /usr/local/bin/kubectl
 
 # Simple testing logic for making sure versions are set
 if [[ -n "${KUBE_CTL_TEST_VERSION}" ]]; then

--- a/cf-deploy-kubernetes.sh
+++ b/cf-deploy-kubernetes.sh
@@ -83,9 +83,15 @@ elif (( "${SERVER_VERSION}" <= "6" )); then
     KUBE_CTL="6"
 fi
 
+# Assign kubectl version unless default
+if (( "$KUBE_CTL" != "14" )); then
+    cp -f /usr/local/bin/kubectl1.${KUBE_CTL} /usr/local/bin/kubectl
+fi
+
 # Simple testing logic for making sure versions are set
 if [[ -z "${KUBE_CTL_TEST_VERSION}" ]]; then
-    if [ "${KUBE_CTL}" == "${KUBE_CTL_TEST_VERSION}" ]; then
+    KUBE_CTL_VERSION=`kubectl version --client --short`
+    if [[ "${KUBE_CTL_VERSION}" == *"${KUBE_CTL_TEST_VERSION}"* ]]; then
         echo "Version correctly set"
         echo "Kubectl Version: ${KUBE_CTL}"
         echo "Test Version: ${KUBE_CTL_TEST_VERSION}"
@@ -96,11 +102,6 @@ if [[ -z "${KUBE_CTL_TEST_VERSION}" ]]; then
         echo "Test Version: ${KUBE_CTL_TEST_VERSION}"
         exit 1
 fi    
-
-# Assign kubectl version unless default
-if (( "$KUBE_CTL" != "14" )); then
-    cp -f /usr/local/bin/kubectl1.${KUBE_CTL} /usr/local/bin/kubectl
-fi
 
 [ ! -f "${deployment_file}" ] && echo "Couldn't find $deployment_file file at $(pwd)" && exit 1;
 

--- a/cf-deploy-kubernetes.sh
+++ b/cf-deploy-kubernetes.sh
@@ -73,7 +73,7 @@ fi
 # Determine appropriate kubectl version
 if [[ "${SERVER_VERSION}" -eq "15" ]]; then
     KUBE_CTL="15"
-elif [[ "${SERVER_VERSION}" -le "13" && "${SERVER_VERSION}" -ge "14" ]]; then
+elif [[ "${SERVER_VERSION}" -le "14" && "${SERVER_VERSION}" -ge "13" ]]; then
     KUBE_CTL="14"
 elif [[ "${SERVER_VERSION}" -le "12" && "${SERVER_VERSION}" -ge "11" ]]; then
     KUBE_CTL="12"

--- a/cf-deploy-kubernetes.sh
+++ b/cf-deploy-kubernetes.sh
@@ -99,11 +99,11 @@ if [[ -n "${KUBE_CTL_TEST_VERSION}" ]]; then
     echo "Testing kubectl version is set..."
     if [[ "${KUBE_CTL_VERSION}" == *"${KUBE_CTL_TEST_VERSION}"* ]]; then
         echo "Version correctly set"
-        echo "Kubectl Version: ${KUBE_CTL}"
+        echo "Kubectl Version: ${KUBE_CTL_VERSION}"
         echo "Test Version: ${KUBE_CTL_TEST_VERSION}"
         exit 0
     else
-        echo "Kubectl Version: ${KUBE_CTL}"
+        echo "Kubectl Version: ${KUBE_CTL_VERSION}"
         echo "Test Version: ${KUBE_CTL_TEST_VERSION}"
         fatal "Version Mismatch!!!"
         exit 1


### PR DESCRIPTION
Adding in support for all Kubernetes versions using the +1 version support Kubernetes claims.

Added tests to our pipelines to confirm the kubectl being set matches the intended version.