### PR TITLE
reverting some changes while keeping support for versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,9 @@ RUN curl -o kubectl1.15 -L https://storage.googleapis.com/kubernetes-release/rel
 RUN curl -o kubectl1.14 -L https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubectl
 RUN curl -o kubectl1.13 -L https://storage.googleapis.com/kubernetes-release/release/v1.13.0/bin/linux/amd64/kubectl
 RUN curl -o kubectl1.12 -L https://storage.googleapis.com/kubernetes-release/release/v1.12.0/bin/linux/amd64/kubectl
+RUN curl -o kubectl1.11 -L https://storage.googleapis.com/kubernetes-release/release/v1.11.0/bin/linux/amd64/kubectl
 RUN curl -o kubectl1.10 -L https://storage.googleapis.com/kubernetes-release/release/v1.10.0/bin/linux/amd64/kubectl
+RUN curl -o kubectl1.9 -L https://storage.googleapis.com/kubernetes-release/release/v1.9.0/bin/linux/amd64/kubectl
 RUN curl -o kubectl1.6 -L https://storage.googleapis.com/kubernetes-release/release/v1.6.0/bin/linux/amd64/kubectl
 
 FROM alpine:3.9
@@ -18,13 +20,15 @@ COPY --from=builder kubectl1.15 /usr/local/bin/
 COPY --from=builder kubectl1.14 /usr/local/bin/
 COPY --from=builder kubectl1.13 /usr/local/bin/
 COPY --from=builder kubectl1.12 /usr/local/bin/
+COPY --from=builder kubectl1.11 /usr/local/bin/
 COPY --from=builder kubectl1.10 /usr/local/bin/
+COPY --from=builder kubectl1.9 /usr/local/bin/
 COPY --from=builder kubectl1.6 /usr/local/bin/
 
 # Set Default
-COPY --from=builder kubectl1.14 /usr/local/bin/kubectl
+COPY --from=builder kubectl1.6 /usr/local/bin/kubectl
 
-RUN chmod +x /usr/local/bin/kubectl /usr/local/bin/kubectl1.6 /usr/local/bin/kubectl1.10 /usr/local/bin/kubectl1.12 /usr/local/bin/kubectl1.13 /usr/local/bin/kubectl1.14 /usr/local/bin/kubectl1.15
+RUN chmod +x /usr/local/bin/kubectl /usr/local/bin/kubectl1.6 /usr/local/bin/kubectl1.9 /usr/local/bin/kubectl1.10 /usr/local/bin/kubectl1.11 /usr/local/bin/kubectl1.12 /usr/local/bin/kubectl1.13 /usr/local/bin/kubectl1.14 /usr/local/bin/kubectl1.15
 
 WORKDIR /
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ The following env variables control the deployment configuration:
 4. KUBECTL_ACTION - means an action for `kubectl <action>`. Valid values are apply|create|replace. Default is "apply"
 
 Optional:
-`SERVER_VERSION` - Used mainly for testing. Manually set the Minor Kubernetes version.
+`SERVER_VERSION` - Manually set the Minor Kubernetes version.  Supports 9-15.
+If left blank version 13 and older will use kubectl v1.6.0
 
 # Usage in codefresh.io
 

--- a/cf-deploy-kubernetes.sh
+++ b/cf-deploy-kubernetes.sh
@@ -64,29 +64,26 @@ fi
 if [[ -n "${SERVER_VERSION}" ]]; then
     # Dynamically define SERVER_VERSION using kube context
     echo "Statically defined version: ${SERVER_VERSION}"
+    KUBE_CTL=${SERVER_VERSION}
 else
     # Dynamically define SERVER_VERSION using kube context
     SERVER_VERSION=$(kubectl version --short=true --context "${KUBECONTEXT}" | grep -i server | cut -d ':' -f2 | cut -d '.' -f2 | sed 's/[^0-9]*//g')
     echo "Dynamically defined version: ${SERVER_VERSION}"
 fi
 
-# Determine appropriate kubectl version
-if [[ "${SERVER_VERSION}" -eq "15" ]]; then
-    KUBE_CTL="15"
-elif [[ "${SERVER_VERSION}" -eq "14" ]]; then
-    KUBE_CTL="14"
-elif [[ "${SERVER_VERSION}" -eq "13" ]]; then
-    KUBE_CTL="13"
-elif [[ "${SERVER_VERSION}" -le "12" && "${SERVER_VERSION}" -ge "11" ]]; then
-    KUBE_CTL="12"
-elif [[ "${SERVER_VERSION}" -le "10" && "${SERVER_VERSION}" -ge "9" ]]; then
-    KUBE_CTL="10"
-elif [[ "${SERVER_VERSION}" -ge "6" ]]; then
-    KUBE_CTL="6"
-else
-    echo "kubectl version: v1.${SERVER_VERSION}"
-    fatal "Version Not Supported!!!"
-    exit 1
+# Determine appropriate kubectl version if not statically set
+if [[ -z "${KUBE_CTL}" ]]; then
+    if [[ "${SERVER_VERSION}" -eq "15" ]]; then
+        KUBE_CTL="15"
+    elif [[ "${SERVER_VERSION}" -eq "14" ]]; then
+        KUBE_CTL="14"
+    elif [[ "${SERVER_VERSION}" -le "13" && "${SERVER_VERSION}" -ge "6" ]]; then
+        KUBE_CTL="6"
+    else
+        echo "kubectl version: v1.${SERVER_VERSION}"
+        fatal "Version Not Supported!!!"
+        exit 1
+    fi
 fi
 
 # Assign kubectl version 


### PR DESCRIPTION
@francisco-codefresh or @luis-codefresh please review.

Versions 14 & 15 are set the same as before using dynamic configuration.

Versions 13 and older default back to v1.6.0 which was default before my updates.

Manual override is available now through variable `SERVER_VERSION`.

Documentation updated for that fact.