### PR TITLE
Add support for Kubernetes 12 and 13

### DIFF
--- a/cf-deploy-kubernetes.sh
+++ b/cf-deploy-kubernetes.sh
@@ -72,6 +72,8 @@ else
     SERVER_VERSION=$(kubectl version --short=true --context "${KUBECONTEXT}" | grep -i server | cut -d ':' -f2 | cut -d '.' -f2 | sed 's/[^0-9]*//g')
     echo "Server minor version: $SERVER_VERSION"
     if (( "$SERVER_VERSION" <= "6" )); then cp -f /usr/local/bin/kubectl1.6 /usr/local/bin/kubectl; fi 2>/dev/null
+    if (( "$SERVER_VERSION" == "12" )); then cp -f /usr/local/bin/kubectl1.14 /usr/local/bin/kubectl; fi 2>/dev/null
+    if (( "$SERVER_VERSION" == "13" )); then cp -f /usr/local/bin/kubectl1.14 /usr/local/bin/kubectl; fi 2>/dev/null
     if (( "$SERVER_VERSION" == "14" )); then cp -f /usr/local/bin/kubectl1.14 /usr/local/bin/kubectl; fi 2>/dev/null
     if (( "$SERVER_VERSION" >= "15" )); then cp -f /usr/local/bin/kubectl1.15 /usr/local/bin/kubectl; fi 2>/dev/null
     [ ! -f "${deployment_file}" ] && echo "Couldn't find $deployment_file file at $(pwd)" && exit 1;


### PR DESCRIPTION
The default version in this image is Kubernetes 1.10 which isn't compatible with 1.12 or 1.13. This change will patch in 1.14 which is compatible with 1.12 and 1.13. 

1.13 is currently the default Kubernetes version on Azure and several other providers. So until this patch is accepted, the step is by default broken for many users.