### PR TITLE
Make default behavior to match kubectl versions when we have them 

### DIFF
--- a/cf-deploy-kubernetes.sh
+++ b/cf-deploy-kubernetes.sh
@@ -72,6 +72,9 @@ else
     SERVER_VERSION=$(kubectl version --short=true --context "${KUBECONTEXT}" | grep -i server | cut -d ':' -f2 | cut -d '.' -f2 | sed 's/[^0-9]*//g')
     echo "Server minor version: $SERVER_VERSION"
     if (( "$SERVER_VERSION" <= "6" )); then cp -f /usr/local/bin/kubectl1.6 /usr/local/bin/kubectl; fi 2>/dev/null
+    if (( "$SERVER_VERSION" == "11" )); then cp -f /usr/local/bin/kubectl1.11 /usr/local/bin/kubectl; fi 2>/dev/null
+    if (( "$SERVER_VERSION" == "12" )); then cp -f /usr/local/bin/kubectl1.12 /usr/local/bin/kubectl; fi 2>/dev/null
+    if (( "$SERVER_VERSION" == "13" )); then cp -f /usr/local/bin/kubectl1.13 /usr/local/bin/kubectl; fi 2>/dev/null
     if (( "$SERVER_VERSION" == "14" )); then cp -f /usr/local/bin/kubectl1.14 /usr/local/bin/kubectl; fi 2>/dev/null
     if (( "$SERVER_VERSION" >= "15" )); then cp -f /usr/local/bin/kubectl1.15 /usr/local/bin/kubectl; fi 2>/dev/null
     [ ! -f "${deployment_file}" ] && echo "Couldn't find $deployment_file file at $(pwd)" && exit 1;


### PR DESCRIPTION
Without this PR the step will fail with Kubernetes version APIs 1.12 and 1.13. This PR sets 1.11, 1.12, and 1.13 to use the exact match version rather than trying to rely on backwards or forwards compatibility. 

AKS uses 1.13 by default today so the step will fail for those users. 