### PR TITLE
Remove 'kubectl convert'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,8 @@ COPY --from=builder kubectl1.6 /usr/local/bin/
 
 RUN chmod +x /usr/local/bin/kubectl /usr/local/bin/kubectl1.6 /usr/local/bin/kubectl1.11 /usr/local/bin/kubectl1.12 /usr/local/bin/kubectl1.13 /usr/local/bin/kubectl1.14 /usr/local/bin/kubectl1.15 /usr/local/bin/kubectl1.16
 
+RUN ls -la /usr/local/bin/kubectl*
+
 WORKDIR /
 
 ADD cf-deploy-kubernetes.sh /cf-deploy-kubernetes

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,8 +28,6 @@ COPY --from=builder kubectl1.6 /usr/local/bin/
 
 RUN chmod +x /usr/local/bin/kubectl /usr/local/bin/kubectl1.6 /usr/local/bin/kubectl1.11 /usr/local/bin/kubectl1.12 /usr/local/bin/kubectl1.13 /usr/local/bin/kubectl1.14 /usr/local/bin/kubectl1.15 /usr/local/bin/kubectl1.16
 
-RUN ls -la /usr/local/bin/kubectl*
-
 WORKDIR /
 
 ADD cf-deploy-kubernetes.sh /cf-deploy-kubernetes

--- a/cf-deploy-kubernetes.sh
+++ b/cf-deploy-kubernetes.sh
@@ -79,6 +79,8 @@ $(dirname $0)/template.sh "$deployment_file" > "$DEPLOYMENT_FILE" || fatal "Fail
 echo -e "\n\n---> Kubernetes objects to deploy in  $deployment_file :"
 KUBECTL_OBJECTS=/tmp/deployment.objects
 kubectl apply \
+    --context "${KUBECONTEXT}" \
+    --namespace "${KUBERNETES_NAMESPACE}" \
     --dry-run \
     -f "$DEPLOYMENT_FILE" \
     -o go-template \

--- a/service.yaml
+++ b/service.yaml
@@ -1,1 +1,1 @@
-version: 16.1.0
+version: 16.1.1


### PR DESCRIPTION
## Overview

The `cf-deploy-kubernetes.sh` generates __KUBECTL_OBJECTS=/tmp/deployment.objects__ file with a list of resources:
```sh
<Resource Kind> <Resource Name>
```
To get it script runs `kubctl convert -o custom-columns ...`, or in case of failure - uses bash hell with sed and awk to parse deployment yaml.

Since the `kubectl convert` subcommand differs from version 1.10 to version 1.15 and is completely removed in version 1.17, the `kubectl apply --dry-run -o go-template` command will be used instead of those two methods.