### PR TITLE
Fix KUBECTL_ACTION and README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ steps:
   deploy-to-kubernetes:
     image: codefresh/cf-deploy-kubernetes
     tag: latest
-    working-directory: ${{initial-clone}}
+    working_directory: ${{clone}}
     commands:
       - /cf-deploy-kubernetes deployment.yml
     environment:

--- a/cf-deploy-kubernetes.sh
+++ b/cf-deploy-kubernetes.sh
@@ -78,7 +78,7 @@ $(dirname $0)/template.sh "$deployment_file" > "$DEPLOYMENT_FILE" || fatal "Fail
 
 echo -e "\n\n---> Kubernetes objects to deploy in  $deployment_file :"
 KUBECTL_OBJECTS=/tmp/deployment.objects
-kubectl apply \
+kubectl $KUBECTL_ACTION \
     --context "${KUBECONTEXT}" \
     --namespace "${KUBERNETES_NAMESPACE}" \
     --dry-run \

--- a/service.yaml
+++ b/service.yaml
@@ -1,2 +1,2 @@
-version: 16.1.1
+version: 16.1.2
 


### PR DESCRIPTION
This PR fixes the `cf-deploy-kubernetes.sh` script to have the `kubectl` `--dry-run` use the `$KUBECTL_ACTION` instead of `apply` by default.  This should fix an errors or warnings that arise by the referenced `$DEPLOYMENT_FILE` being run with `apply` versus `$KUBECTL_ACTION`.

This PR also updates the README to use the conventional parameters instead of the deprecated ones.